### PR TITLE
Bump pendulum for Python 3.12 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 irctokens ~=2.0.2
-pendulum  ~=2.1.0
+pendulum  ~=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setuptools.setup(
         "Operating System :: Microsoft :: Windows",
         "Topic :: Communications :: Chat :: Internet Relay Chat"
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=install_requires
 )


### PR DESCRIPTION
Related: https://github.com/sdispater/pendulum/issues/696

Unit tests showing deprecation warnings, see https://github.com/sdispater/pendulum/pull/803